### PR TITLE
Appearance callbacks. View's loading order. Preloading option.

### DIFF
--- a/YTPageController/Classes/YTPageController.h
+++ b/YTPageController/Classes/YTPageController.h
@@ -47,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) IBInspectable BOOL bounces;
 
+/**
+ A Boolean value that enables force preloading views of next and previous viewControllers.
+ Use with caution as preloading triggers viewWillAppear/viewWillDisappear callbacks when view is not visible yet.
+ Default value is NO.
+ */
+@property (nonatomic) IBInspectable BOOL shouldPreloadViews;
 
 /**
  If the value of this property is YES, scrolling is enabled, otherwise disabled.

--- a/YTPageController/Classes/YTPageController.m
+++ b/YTPageController/Classes/YTPageController.m
@@ -906,7 +906,8 @@ typedef NS_ENUM(NSInteger, YTPageTransitionStartReason) {
 }
 
 - (void)preloadViewController:(UIViewController *)viewController forIndex:(NSInteger)index {
-    if (![_cachedViews objectForKey:@(index)]) {
+    BOOL isAlreadyLoaded = viewController.view.superview != nil;
+    if (![_cachedViews objectForKey:@(index)] && !isAlreadyLoaded) {
         // We mimic behaviour of UINavigationController, when we trying to pop viewController
         // using panGestureRecognizer, but then cancel it. In other words we should call:
         // WillAppear -> WillDisappear -> DidDisappear


### PR DESCRIPTION
Hey @Yeatse.
I really like your project - the best pagination solution I ever found (much better than Apple one).

Unfortunately I faced with few problems in my project:
1) next cell's view loaded in the middle of transition animation (that's because of UICollectionView cells loading behaviour). That makes user experience bad because of not smooth animation.
2) viewWillAppear/disappear are either not called, or called at wrong time.
3) user experience is even more worse while working with heavy viewControllers (complex view hierarchy, complex drawing, etc). These kind of viewController should be loaded in advance - before transition.

This Pull Request is aimed to fix it.
1) now view is loaded on "cellWillDisplay" callback - so we'll load view before animation instead of in the middle of animation.
2) this was reworked, so now willAppear/didAppear/willDisappear/didDisappear - all works correctly (even in case of cancel).
3) added option (Default: NO) to preload next/previous viewController's view. Unfortunately this brakes (2), but I can't see the way to add viewController's view as subview without appearance callbacks being called. Any idea very welcome. User should make a choice: smooth animation or correct appearance callbacks for logic. 

Code Review, criticism and feedback is appreciated! 